### PR TITLE
Fix for issue #35

### DIFF
--- a/src/FMUSimulator.jl
+++ b/src/FMUSimulator.jl
@@ -594,7 +594,7 @@ function main(pathToFMU::String)
 
         # Iterate with explicit euler method
         k = 0
-        k_max = 1000
+        k_max = 1000000
         while (fmu.simulationData.time < fmu.experimentData.stopTime) && (k < k_max)
             k += 1
             getDerivatives!(fmu)
@@ -632,6 +632,10 @@ function main(pathToFMU::String)
             writeValuesToCSV(fmu)
 
             # Handle events
+        end
+
+        if k>=k_max
+            error("Maximum number of allowed steps ($k_max) reached.")
         end
 
         # Terminate Simulation

--- a/src/modelDescriptionParsing.jl
+++ b/src/modelDescriptionParsing.jl
@@ -171,7 +171,7 @@ function getDefaultExperiment(xroot::XMLElement)
         if stepSize != nothing
             stepSize = parse(Float64, stepSize)
         else
-            stepSize = 2e-3
+            stepSize = round((stopTime - startTime)/500, digits=6)
         end
 
         defaultExperiment = ExperimentData(startTime, stopTime, tolerance, stepSize)


### PR DESCRIPTION
  - Set default stepSize to (stopTime-startTime)/500 rounded to 6 digits if no stepSize is provided from modelDescription.xml.
  - Increased maximum number of allowed steps to 1,000,000.
  - Added error when reaching maximum number of steps.